### PR TITLE
Add dark mode functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <body>
   <div class="container">
 
+    <button id="darkModeToggle">Toggle Dark Mode</button>
     <div class="tag">WEB DESIGNER Shahriyor</div>
     <h2>Lorem ipsum dolor sit amet consectetur adipisicing elit. Suscipit voluptates, placeat eius ullam velit consequuntur non quam aliquid commodi illum?</h2>
 
@@ -63,6 +64,32 @@
     </section>
 
   </div>
+  <script>
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    const body = document.body;
+
+    // Function to apply the stored theme
+    function applyStoredTheme() {
+      const isDarkMode = localStorage.getItem('darkMode') === 'true';
+      if (isDarkMode) {
+        body.classList.add('dark-mode');
+      } else {
+        body.classList.remove('dark-mode');
+      }
+    }
+
+    // Function to toggle dark mode
+    function toggleDarkMode() {
+      body.classList.toggle('dark-mode');
+      localStorage.setItem('darkMode', body.classList.contains('dark-mode'));
+    }
+
+    // Apply theme on initial load
+    applyStoredTheme();
+
+    // Add event listener to the toggle button
+    darkModeToggle.addEventListener('click', toggleDarkMode);
+  </script>
 </body>
 <footer class="contact">
   <p>📞 +998 978178408</p>

--- a/style.css
+++ b/style.css
@@ -1,8 +1,20 @@
+:root {
+  --background-color: #fff;
+  --text-color: #000;
+  --text-color-inverted: #fff;
+  --background-color-inverted: #000;
+  --tag-background-color: #ffd700;
+  --highlight-background-color: #e6007e;
+  --secondary-text-color: #444;
+  --border-color: #ccc;
+  --tertiary-text-color: #333;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 40px;
-  background-color: #fff;
-  color: #000;
+  background-color: var(--background-color);
+  color: var(--text-color);
 }
 
 .container {
@@ -12,8 +24,8 @@ body {
 
 .tag {
   display: inline-block;
-  background-color: #ffd700;
-  color: #000;
+  background-color: var(--tag-background-color);
+  color: var(--background-color-inverted);
   padding: 3px 8px;
   font-size: 12px;
   font-weight: bold;
@@ -30,8 +42,8 @@ body {
 
 
 .highlight {
-  background-color: #e6007e;
-  color: #fff;
+  background-color: var(--highlight-background-color);
+  color: var(--text-color-inverted);
   padding: 3px 10px;
   border-radius: 8px;
 }
@@ -81,14 +93,26 @@ body {
 
 .description p {
   font-size: 13px;
-  color: #444;
+  color: var(--secondary-text-color);
 }
 .contact {
   margin-top: 40px;
   padding-top: 20px;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid var(--border-color);
   text-align: center;
   font-size: 14px;
-  color: #333;
+  color: var(--tertiary-text-color);
+}
+
+.dark-mode {
+  --background-color: #121212;
+  --text-color: #e0e0e0;
+  --text-color-inverted: #121212;
+  --background-color-inverted: #e0e0e0;
+  --tag-background-color: #bb86fc;
+  --highlight-background-color: #03dac6;
+  --secondary-text-color: #a0a0a0;
+  --border-color: #444;
+  --tertiary-text-color: #b0b0b0;
 }
 


### PR DESCRIPTION
This commit introduces a dark mode feature to the website.

Key changes:
- Modified `style.css` to use CSS variables for theming.
- Added a `dark-mode` class in `style.css` with specific styles for the dark theme.
- Added a toggle button to `index.html` to switch between light and dark modes.
- Implemented JavaScript in `index.html` to:
    - Handle the toggle functionality.
    - Persist your theme preference using local storage.
    - Apply the saved preference on page load.

I reviewed the code, and it appears to function correctly.